### PR TITLE
Fix: Corregir logout (error 403) y generación de ID en Token

### DIFF
--- a/src/main/java/com/hd/GestionTareas/auth/repository/Token.java
+++ b/src/main/java/com/hd/GestionTareas/auth/repository/Token.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public final class Token {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(unique = true, columnDefinition = "TEXT")

--- a/src/main/java/com/hd/GestionTareas/auth/service/AuthService.java
+++ b/src/main/java/com/hd/GestionTareas/auth/service/AuthService.java
@@ -51,7 +51,7 @@ public class AuthService {
 
         var cookie = new jakarta.servlet.http.Cookie("USER_SESSION", token);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        cookie.setSecure(false);
         cookie.setPath("/");
         cookie.setMaxAge((int) (jwtExpiration)/1000);
 

--- a/src/main/java/com/hd/GestionTareas/config/SecurityConfig.java
+++ b/src/main/java/com/hd/GestionTareas/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -55,6 +56,9 @@ public class SecurityConfig {
                                 .addLogoutHandler(this::logout)
                                 .deleteCookies("USER_SESSION")
                                 .invalidateHttpSession(true)
+                                .logoutSuccessHandler((request, response, authentication) -> {
+                                    response.setStatus(HttpStatus.OK.value());
+                                })
                 );
 
 


### PR DESCRIPTION
- Soluciona el error "403 Forbidden" en el logout causado por no añadir una respuesta http por defecto
- Cambia el ID de la entidad Token de 'auto' a 'identity' para evitar incongruencias, ej: la fila 1 tenia el id "134"